### PR TITLE
Clear ThreadLocal request atttribute after response is processed

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ PRIMARY AUTHORS are and/or have been (alphabetic order):
 
 
 CONTRIBUTORS are and/or have been (alphabetic order):
+    - Lucas Wiman
     -
 
 

--- a/django_tools/__init__.py
+++ b/django_tools/__init__.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 
-__version__ = "0.29.2"
+__version__ = "0.30.0"
 

--- a/django_tools/middlewares/ThreadLocal.py
+++ b/django_tools/middlewares/ThreadLocal.py
@@ -25,7 +25,7 @@
     # Get the current request object:
     request = ThreadLocal.get_current_request()
     
-    # You can get the current user directy with:
+    # You can get the current user directly with:
     user = ThreadLocal.get_current_user()
     --------------------------------------------------------------------------
 
@@ -47,7 +47,7 @@ _thread_locals = local()
 
 
 def get_current_request():
-    """ returns the request object for this thead """
+    """ returns the request object for this thread """
     return getattr(_thread_locals, "request", None)
 
 

--- a/django_tools/middlewares/ThreadLocal.py
+++ b/django_tools/middlewares/ThreadLocal.py
@@ -62,3 +62,8 @@ class ThreadLocalMiddleware(object):
     """ Simple middleware that adds the request object in thread local storage."""
     def process_request(self, request):
         _thread_locals.request = request
+
+    def process_response(self, request, response):
+        if hasattr(_thread_locals, 'request'):
+            del _thread_locals.request
+        return response

--- a/django_tools_test_project/django_tools_test_app/urls.py
+++ b/django_tools_test_project/django_tools_test_app/urls.py
@@ -12,10 +12,13 @@ from __future__ import absolute_import, division, print_function
 
 
 from django_tools_test_project.django_tools_test_app.views import display_site
+from django_tools_test_project.django_tools_test_app.views import get_current_get_parameters
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
 
 urlpatterns = patterns('',
     url(r'^display_site/$', display_site),
+    url(r'^get_current_get_parameters/$', get_current_get_parameters),
+
     url(r'^admin/', include(admin.site.urls)),
 )

--- a/django_tools_test_project/django_tools_test_app/urls.py
+++ b/django_tools_test_project/django_tools_test_app/urls.py
@@ -13,12 +13,14 @@ from __future__ import absolute_import, division, print_function
 
 from django_tools_test_project.django_tools_test_app.views import display_site
 from django_tools_test_project.django_tools_test_app.views import get_current_get_parameters
+from django_tools_test_project.django_tools_test_app.views import raise_exception
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
 
 urlpatterns = patterns('',
     url(r'^display_site/$', display_site),
     url(r'^get_current_get_parameters/$', get_current_get_parameters),
+    url(r'^raise_exception/$', raise_exception),
 
     url(r'^admin/', include(admin.site.urls)),
 )

--- a/django_tools_test_project/django_tools_test_app/views.py
+++ b/django_tools_test_project/django_tools_test_app/views.py
@@ -10,10 +10,13 @@
 
 from __future__ import absolute_import, division, print_function
 
+import json
 
 from django.http import HttpResponse
 from django.conf import settings
 from django.contrib.sites.models import Site
+
+from django_tools.middlewares.ThreadLocal import get_current_request
 
 
 
@@ -30,3 +33,10 @@ def display_site(request):
 
 
 
+
+
+def get_current_get_parameters(request):
+    """
+    Returns a JSON version of request.GET from the current request
+    """
+    return HttpResponse(json.dumps(get_current_request().GET))

--- a/django_tools_test_project/django_tools_test_app/views.py
+++ b/django_tools_test_project/django_tools_test_app/views.py
@@ -33,6 +33,12 @@ def display_site(request):
 
 
 
+def raise_exception(request):
+    """
+    This view just raises an exception as a way to test middleware exception
+    handling.
+    """
+    raise Exception()
 
 
 def get_current_get_parameters(request):

--- a/django_tools_test_project/test_settings.py
+++ b/django_tools_test_project/test_settings.py
@@ -26,6 +26,7 @@ CACHES = {
 
 MIDDLEWARE_CLASSES = (
     'django_tools.dynamic_site.middleware.DynamicSiteMiddleware',
+    'django_tools.middlewares.ThreadLocal.ThreadLocalMiddleware',
 )
 
 INSTALLED_APPS = (

--- a/tests/test_ThreadLocal_middleware.py
+++ b/tests/test_ThreadLocal_middleware.py
@@ -1,0 +1,19 @@
+import json
+
+from django.test import TestCase
+
+from django_tools.middlewares.ThreadLocal import get_current_request
+
+
+class TestGetCurrentRequest(TestCase):
+    def test_current_request_receives_current_request(self):
+        response = self.client.get('/get_current_get_parameters/?')
+        current_get_parameters = json.loads(response.content)
+        self.assertEqual(current_get_parameters, {})
+        response = self.client.get('/get_current_get_parameters/?foo=bar')
+        current_get_parameters = json.loads(response.content)
+        self.assertEqual(current_get_parameters, {'foo': 'bar'})
+
+    def test_current_request_is_cleared_after_request_is_finished(self):
+        response = self.client.get('/get_current_get_parameters/')
+        self.assertEqual(get_current_request(), None)

--- a/tests/test_ThreadLocal_middleware.py
+++ b/tests/test_ThreadLocal_middleware.py
@@ -18,7 +18,7 @@ class TestGetCurrentRequest(TestCase):
         response = self.client.get('/get_current_get_parameters/')
         self.assertEqual(get_current_request(), None)
 
-    def test_current_Request_is_cleared_when_exception_is_raised(self):
+    def test_current_request_is_cleared_when_exception_is_raised(self):
         with self.assertRaises(Exception):
             response = self.client.get('/raise_exception/')
         self.assertEqual(get_current_request(), None)

--- a/tests/test_ThreadLocal_middleware.py
+++ b/tests/test_ThreadLocal_middleware.py
@@ -8,10 +8,10 @@ from django_tools.middlewares.ThreadLocal import get_current_request
 class TestGetCurrentRequest(TestCase):
     def test_current_request_receives_current_request(self):
         response = self.client.get('/get_current_get_parameters/?')
-        current_get_parameters = json.loads(response.content)
+        current_get_parameters = json.loads(response.content.decode('utf-8'))
         self.assertEqual(current_get_parameters, {})
         response = self.client.get('/get_current_get_parameters/?foo=bar')
-        current_get_parameters = json.loads(response.content)
+        current_get_parameters = json.loads(response.content.decode('utf-8'))
         self.assertEqual(current_get_parameters, {'foo': 'bar'})
 
     def test_current_request_is_cleared_after_request_is_finished(self):

--- a/tests/test_ThreadLocal_middleware.py
+++ b/tests/test_ThreadLocal_middleware.py
@@ -17,3 +17,8 @@ class TestGetCurrentRequest(TestCase):
     def test_current_request_is_cleared_after_request_is_finished(self):
         response = self.client.get('/get_current_get_parameters/')
         self.assertEqual(get_current_request(), None)
+
+    def test_current_Request_is_cleared_when_exception_is_raised(self):
+        with self.assertRaises(Exception):
+            response = self.client.get('/raise_exception/')
+        self.assertEqual(get_current_request(), None)


### PR DESCRIPTION
@jedie This pull request updates the `ThreadLocal` middleware so that the thread local reference to the `request` object is cleared when the response is processed by the middleware.

## Issue Description
This is unlikely to matter in practice since a server will overwrite the previous `_thread_locals.request` when it receives a new request.

The use case this is intended to fix is:
- A function `f()` is used on both the front end and back end of an application.
- It collects metadata when used on the front end, for example to record an audit log of user actions. If `get_current_{request,user}` is called, it creates a model entry with a foreign key referencing the change the user made.
- When used on the backend, no model entry `M` is created, or the `User` foreign key is NULL.
- A test suite runs:
  - It first tests the front-end audit logging, using a simulated request from django's test client, which sets the `_thread_locals.request` variable. The `User` object is created as part of the test, then destroyed when the database transaction is rolled back by the `tearDown` method.
  - It subsequently runs a test of the back end functionality, which attempts to save an audit log of the action from the user on the previous test. Since this user no longer exists, a database integrity error is raised.

## Changes
- Adds a `ThreadLocalMiddleware.process_response` method, which is part of the Django middleware API: https://docs.djangoproject.com/en/1.8/topics/http/middleware/#process-response This method clears the `request` variable if it is defined.
- Corrects some typos in the `ThreadLocal` module's documentation.

## Testing

I added two views to the example app. One that returns the GET parameters from the current request, and one that simply raises an exception. I added tests that assert:
- The current GET parameters are actually returned (i.e. that `get_current_request` actually returns the current request). This passed on the master branch, and is just included for completeness.
- When a successful request is executed, the `request` reference is cleared. This failed using the code on the master branch.
- When an unsuccessful request is executed (in the `raise_exception` view), the `request` reference is cleared. This failed using the code on the master branch.

Thanks for maintaining this library!