### PR TITLE
Clean up spelling and grammar

### DIFF
--- a/README.creole
+++ b/README.creole
@@ -95,14 +95,14 @@ usage/tests:
 === DOM compare in unittests
 
 The Problem:
-You can’t easy check if e.g. some form input fields are in the reponse,
+You can’t easy check if e.g. some form input fields are in the response,
 because the form rendering use a dict for storing all html attributes.
 So, the ordering of form field attributes are not sorted and varied.
 
 The Solution:
 You need to parse the response content into a DOM tree and compare nodes.
 
-We add the gread work of Gregor Müllegger at his GSoC 2011 form-rendering branch.
+We add the great work of Gregor Müllegger at his GSoC 2011 form-rendering branch.
 You will have the following assert methods inherit from: django_tools.unittest_utils.unittest_base.BaseTestCase
 
 * self.assertHTMLEqual() – for compare two HTML DOM trees

--- a/django_tools/fields/directory.py
+++ b/django_tools/fields/directory.py
@@ -2,7 +2,7 @@
 
 
 """
-    direcotory selection
+    directory selection
     ~~~~~~~~~~~~~~~~~~~~
 
     :copyleft: 2011 by the django-tools team, see AUTHORS for more details.

--- a/django_tools/fields/url.py
+++ b/django_tools/fields/url.py
@@ -26,11 +26,11 @@ from django_tools.validators import URLValidator2
 
 from django.core import validators
 from django.db.models.fields import CharField as OriginModelCharField
-from django.forms.fields import CharField as OriginFormsCahrField
+from django.forms.fields import CharField as OriginFormsCharField
 from django.utils.translation import ugettext_lazy as _
 
 
-class URLFormField2(OriginFormsCahrField):
+class URLFormField2(OriginFormsCharField):
     """
     A flexible version of the original django form URLField ;)
     

--- a/django_tools/filemanager/filemanager.py
+++ b/django_tools/filemanager/filemanager.py
@@ -117,7 +117,7 @@ class BaseFilemanager(BaseFilesystemBrowser):
             elif os.path.isfile(item_abs_path):
                 item_class = self.FILE_ITEM
             else:
-                messages.info(self.request, "unhandled direcory item: %r" % self.abs_path)
+                messages.info(self.request, "unhandled directory item: %r" % self.abs_path)
                 continue
 
             instance = self.get_filesystem_item_instance(item_class, item, item_abs_path, link_path)

--- a/django_tools/local_sync_cache/LocalSyncCacheMiddleware.py
+++ b/django_tools/local_sync_cache/LocalSyncCacheMiddleware.py
@@ -4,7 +4,7 @@
     Local sync cache Middleware
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     
-    Calles check_state() in every existing LocalSyncCache instance.
+    Calls check_state() in every existing LocalSyncCache instance.
     
     For more information look into DocString in local_sync_cache.py !
     

--- a/django_tools/local_sync_cache/local_sync_cache.py
+++ b/django_tools/local_sync_cache/local_sync_cache.py
@@ -131,7 +131,7 @@ def _get_cache():
 
 
 class LocalSyncCache(dict):
-    INIT_COUNTER = {} # Counts how often __init__ used, should allways be 1!
+    INIT_COUNTER = {} # Counts how often __init__ used, should always be 1!
 
     # Stores all existing instance, used in middleware to call check_state()
     CACHES = []
@@ -163,7 +163,7 @@ class LocalSyncCache(dict):
             logger.error("Error: __init__ for %s was called to often!" % self.id)
             self.INIT_COUNTER[self.id] += 1
 
-        self.request_counter = 0 # Counts how often check_state called (Normaly called one time per request)
+        self.request_counter = 0 # Counts how often check_state called (Normally called one time per request)
         self.own_clear_counter = 0 # Counts how often clear called in this thread
         self.ext_clear_counter = 0 # Counts how often clears from external thread
 

--- a/django_tools/middlewares/QueryLogMiddleware.py
+++ b/django_tools/middlewares/QueryLogMiddleware.py
@@ -3,7 +3,7 @@ Print the query log to standard out.
 
 Useful for optimizing database calls.
 
-Insipired by the method at: <http://www.djangosnippets.org/snippets/344/>
+Inspired by the method at: <http://www.djangosnippets.org/snippets/344/>
 """
 
 class QueryLogMiddleware:

--- a/django_tools/models.py
+++ b/django_tools/models.py
@@ -63,10 +63,10 @@ class UpdateUserBaseModel(models.Model):
     Important: "threadlocals middleware" must be used!
     """
     createby = models.ForeignKey(settings.AUTH_USER_MODEL, editable=False, related_name="%(class)s_createby",
-        null=True, blank=True, # <- If the model used outsite a real request (e.g. unittest, db shell)
+        null=True, blank=True, # <- If the model used outside a real request (e.g. unittest, db shell)
         help_text="User how create this entry.")
     lastupdateby = models.ForeignKey(settings.AUTH_USER_MODEL, editable=False, related_name="%(class)s_lastupdateby",
-        null=True, blank=True, # <- If the model used outsite a real request (e.g. unittest, db shell)
+        null=True, blank=True, # <- If the model used outside a real request (e.g. unittest, db shell)
         help_text="User as last edit this entry.")
 
     def save(self, *args, **kwargs):

--- a/django_tools/template/filters.py
+++ b/django_tools/template/filters.py
@@ -32,7 +32,7 @@ CHMOD_TRANS_DATA = (
 def chmod_symbol(octal_value):
     """
     Transform a os.stat().st_octal_value octal value to a symbolic string.
-    ignores meta infromation like SUID, SGID or the Sticky-Bit.
+    ignores meta information like SUID, SGID or the Sticky-Bit.
     e.g. 40755 -> rwxr-xr-x
     >>> chmod_symbol(644)
     u'rw-r--r--'

--- a/django_tools/unittest_utils/BrowserDebug.py
+++ b/django_tools/unittest_utils/BrowserDebug.py
@@ -43,7 +43,7 @@ RESPONSE_INFO_ATTR = (
 
 def debug_response(response, browser_traceback=True, msg="", display_tb=True):
     """
-    Display the response content with a error reaceback in a webbrowser.
+    Display the response content with a error traceback in a webbrowser.
     TODO: We should delete the temp files after viewing!
     """
     global BROWSER_TRACEBACK_OPENED

--- a/django_tools/unittest_utils/unittest_base.py
+++ b/django_tools/unittest_utils/unittest_base.py
@@ -184,7 +184,7 @@ class BaseTestCase(BaseUnittestCase, SimpleTestCase):
             raise etype(evalue).with_traceback(etb)
 
     def _get_user(self, usertype):
-        """ return User model instance for the goven usertype"""
+        """ return User model instance for the given usertype"""
         test_user = self._get_userdata(usertype)
         return User.objects.get(username=test_user["username"])
 
@@ -312,7 +312,7 @@ def direct_run(raw_filename):
     A unittest file should add something like this:
     
     if __name__ == "__main__":
-        # Run this unitest directly
+        # Run this unittest directly
         direct_run(__file__)
     """
     appname = os.path.splitext(os.path.basename(raw_filename))[0]

--- a/django_tools/upgrade_virtualenv.py
+++ b/django_tools/upgrade_virtualenv.py
@@ -37,7 +37,7 @@ from optparse import OptionParser
 if __name__ == "__main__":
     # precheck if we in a activated virtualenv
     # if not, the pip import can raise a ImportError, if pip not installed
-    # in the globale python environment
+    # in the global python environment
     if not hasattr(sys, 'real_prefix'):
         print("")
         print("Error: It seems that we are not running in a activated virtualenv!")
@@ -128,7 +128,7 @@ def get_upgradeable():
         if not req.editable:
             packages.append(req.name)
         else:
-            # FIXME: How can we get this needes information easier?
+            # FIXME: How can we get this needed information easier?
             raw_cmd = str(req)
             full_url = raw_cmd.split()[1]
             url, full_version = full_url.rsplit("@", 1)
@@ -195,8 +195,8 @@ def print_options(options):
 
 
 def call_pip(options, *args):
-    pip_executeable = os.path.join(locations.bin_py, "pip")
-    cmd = [pip_executeable, "install", "--upgrade"]
+    pip_executable = os.path.join(locations.bin_py, "pip")
+    cmd = [pip_executable, "install", "--upgrade"]
     if options.verbose:
         cmd.append("--verbose")
     if options.logfile:

--- a/django_tools/utils/http.py
+++ b/django_tools/utils/http.py
@@ -9,7 +9,7 @@
     You can easy get a web page encoding in unicode with HttpRequest().
     
     HttpRequest() and HTTPHandler2() make it possible to get the complete
-    sended request headers. See also:
+    sent request headers. See also:
     http://stackoverflow.com/questions/603856/get-urllib2-request-headers
     
     examples:
@@ -151,7 +151,7 @@ class HttpRequest(object):
     HttpRequest() can take the argument 'timeout' but this works only since Python 2.6
     For Python < 2.6 the timeout TypeError would be silently catch.
     Activate a work-a-round with 'threadunsafe_workaround' to use socket.setdefaulttimeout()
-    But this is not thread-safty!
+    But this is not thread-safe!
     more info: 
         http://kurtmckee.livejournal.com/32616.html (Supporting a timeout in feedparser)
     

--- a/tests/test_dom_asserts.py
+++ b/tests/test_dom_asserts.py
@@ -4,7 +4,7 @@
     Test DOM asserts
     ~~~~~~~~~~~~~~~~
     
-    Test the DOM unitest stuff from
+    Test the DOM unittest stuff from
         Gregor Müllegger GSoC work in the Django soc2011/form-rendering branch
 
     https://github.com/gregmuellegger/django/blob/soc2011%2Fform-rendering/django/test/testcases.py
@@ -118,6 +118,6 @@ class DOMassertTest(BaseTestCase):
 
 
 if __name__ == "__main__":
-    # Run this unitest directly
+    # Run this unittest directly
     unittest.main()
 

--- a/tests/test_limit_to_usergroups.py
+++ b/tests/test_limit_to_usergroups.py
@@ -140,7 +140,7 @@ class LimitToUsergroupsTest2(BaseTestCase, TestCase):
 
 
 if __name__ == "__main__":
-    # Run this unitest directly
+    # Run this unittest directly
     management.call_command('test',
         "django_tools.LimitToUsergroupsTest1",
         "django_tools.LimitToUsergroupsTest2",

--- a/tests/test_local_sync_cache.py
+++ b/tests/test_local_sync_cache.py
@@ -166,7 +166,7 @@ class LocalSyncCacheTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # Run this unitest directly
+    # Run this unittest directly
 #    management.call_command('test', "django_tools.tests.test_local_sync_cache.LocalSyncCacheTest",
 #        verbosity=2,
 #        failfast=True


### PR DESCRIPTION
@jedie This pull request fixes some typos in documentation and variable names, a few of which I noticed in #7.

The exhaustive list of errors was found using the [`scspell`](https://pypi.python.org/pypi/scspell) programming spell checker. I didn't fix spelling in the changelog entries since I'd normally changelogs immutable.

Thanks again!