### PR TITLE
Update language classifiers to show python 3 support.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -226,6 +226,11 @@ setup(
         "Topic :: Internet :: WWW/HTTP :: Site Management",
         "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
     ],
     test_suite="manage.setup_run",
 )


### PR DESCRIPTION
@jedie This PR updates the trove classifiers for `django-tools` to match the list of compatible versions from `tox.ini` (2.7, 3.4, 3.5). This means that compatibility tools like `caniusedpython3` see this package as Python 3 compatible.

Many thanks!