### PR TITLE
Add django 3.1 compatibility

### DIFF
--- a/README.creole
+++ b/README.creole
@@ -738,6 +738,7 @@ Using the old place {{{django_tools.unittest_utils.selenium_utils}}} still works
 == Django compatibility
 
 |= django-tools    |= django version |= python         |
+| >= v0.46.2       | 2.2, 3.0, 3.1   | >= 3.6, pypy3   |
 | >= v0.39         | 1.11, 2.0       | 3.5, 3.6, pypy3 |
 | >= v0.38.1       | 1.8, 1.11       | 3.5, 3.6, pypy3 |
 | >= v0.38.0       | 1.8, 1.11       | 3.5, 3.6        |

--- a/django_tools/unittest_utils/BrowserDebug.py
+++ b/django_tools/unittest_utils/BrowserDebug.py
@@ -21,10 +21,18 @@ from collections import OrderedDict
 from pprint import pformat
 from xml.sax.saxutils import escape
 
+from django import VERSION as django_version
 from django.contrib import messages
 from django.utils.encoding import force_text
 from django.utils.html import strip_tags
-from django.views.debug import get_safe_settings
+
+
+if django_version < "3.1":
+    from django.views.debug import get_safe_settings
+else:
+    from django.views.debug import get_default_exception_reporter_filter
+    get_safe_settings = get_default_exception_reporter_filter().get_safe_settings
+
 
 # https://github.com/jedie/django-tools
 from django_tools.utils.stack_info import get_stack_info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-tools"
-version = "0.46.1"
+version = "0.46.2"
 description = "miscellaneous tools for django"
 
 # Will be generated from README.creole with: "poetry run update_rst_readme"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = py38,py37,py36
+envlist = py{38,37,36}-django{2.2,3.0,3.1}
 skip_missing_interpreters = True
 
 [gh-actions]
@@ -13,6 +13,11 @@ python =
 
 [testenv]
 whitelist_externals = make
+deps =
+    django2.2: django~=2.2.0
+    django3.0: django~=3.0.0
+    django3.1: django~=3.1.0
+
 commands =
     make install
     make pytest


### PR DESCRIPTION
Had trouble getting the tests to run, but this is a start.
Django changed how `get_safe_settings` is called in 3.1